### PR TITLE
Add `if exists` guard to DROP DATABASE command

### DIFF
--- a/deletewiki.sh
+++ b/deletewiki.sh
@@ -4,4 +4,4 @@ set -ex
 rm -rf $PATCHDEMO/wikis/$WIKI
 
 # delete database
-mysql -u patchdemo --password=patchdemo -e "DROP DATABASE patchdemo_$WIKI";
+mysql -u patchdemo --password=patchdemo -e "DROP DATABASE IF EXISTS patchdemo_$WIKI";


### PR DESCRIPTION
This script can sometimes be called when the database is not yet created, currently it spits out errors because non-existing database cannot be deleted.